### PR TITLE
Implement controller endpoints and game logs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template
 from eng import db, socketio
 from controller import load_game_sessions
+from models import PlayerModel
 
 def create_app():
     app = Flask(__name__, template_folder='templates')
@@ -29,7 +30,8 @@ def create_app():
     
     @app.route("/player/<code>/<name>")
     def player(code, name):
-        return render_template("player.html", code=code, name=name)
+        player = PlayerModel.query.filter_by(game_id=code, name=name).first()
+        return render_template("player.html", code=code, name=name, player_id=player.id if player else "")
 
 
     from controller import api

--- a/controller.py
+++ b/controller.py
@@ -2,16 +2,17 @@
 from flask_socketio import emit, join_room
 
 from eng import db, socketio
-from models import GameSessionModel, PlayerModel, MoveLogModel, CityModel, CityConnectionModel, CardModel, DeckOfCardsModel, RoleModel, ColorEnumDB, CardTypeDB, GameStatusDB
+from models import GameSessionModel, PlayerModel, CityModel, RoleModel, GameStatusDB
 
 import secrets
 
 from game import SESSIONS, PandemicGame, Observer
 from data.repo import GameRepository
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 api = Blueprint("api", __name__)
+
 
 def load_game_sessions(app):
     """Загружаем все игровые сессии из базы данных."""
@@ -22,16 +23,84 @@ def load_game_sessions(app):
             game = GameRepository.load_game(gs.code)
             GameRepository.save_game(game)
             SESSIONS.add_session(game)
+            attach_controller(game)
 
 
 class Controller(Observer):
-    def __init__(self):
-        pass
+    def __init__(self, game_code: str | None = None):
+        self.game_code = game_code
 
-    def update(self, message: str):
-        pass
+    def update(self, message: Any):
+        payload: Dict[str, Any] = {"game_id": self.game_code}
 
-controller = Controller()
+        if isinstance(message, dict):
+            payload.update(message)
+            text = message.get("message") or message.get("event") or str(message)
+        else:
+            text = str(message)
+            payload["message"] = text
+
+        payload["text"] = text
+
+        socketio.emit("game:log", payload, room=self.game_code)
+
+
+controllers: Dict[str, Controller] = {}
+
+
+def attach_controller(game: PandemicGame) -> Controller:
+    """
+    Подписывает контроллер на события игры и сохраняет ссылку.
+    """
+    controller = controllers.get(game.code)
+    if controller is None:
+        controller = Controller(game_code=game.code)
+        controllers[game.code] = controller
+        game.add_observer(controller)
+    return controller
+
+
+def _get_game_or_load(code: str) -> PandemicGame | None:
+    """
+    Возвращает игру из оперативной памяти или загружает её из БД.
+    """
+    game = SESSIONS.get_session(code)
+    if game:
+        return game
+
+    game = GameRepository.load_game(code)
+    if game:
+        SESSIONS.add_session(game)
+        attach_controller(game)
+    return game
+
+
+def _get_player_from_game(game: PandemicGame, player_id: int):
+    for player in game.players:
+        if player.id == player_id:
+            return player
+    return None
+
+
+def _get_card_from_game(game: PandemicGame, card_id: Optional[int]):
+    if card_id is None or not hasattr(game, "deck_cards"):
+        return None
+
+    try:
+        searched_id = int(card_id)
+    except Exception:
+        return None
+
+    for card in list(game.deck_cards.draw_pile) + list(game.deck_cards.discard_pile):
+        if card.id == searched_id:
+            return card
+    return None
+
+
+def _emit_log(game_code: str, text: str, payload: Optional[Dict[str, Any]] = None):
+    data = payload.copy() if payload else {}
+    data.update({"game_id": game_code, "text": text})
+    socketio.emit("game:log", data, room=game_code)
 
 @api.route("/health")
 def health():
@@ -46,7 +115,7 @@ def host_create():
     db.session.commit()
 
     game = SESSIONS.create_session(code)
-    game.add_observer(controller)
+    attach_controller(game)
 
     return jsonify({
         "status": "ok",
@@ -59,7 +128,7 @@ def on_host_join(data):
     code = data.get("code")
     join_room(code)
 
-    game = SESSIONS.get_session(code)
+    game = _get_game_or_load(code)
     if not game:
         emit("error", {"message": f"Session {code} not found"})
         return
@@ -78,7 +147,7 @@ def on_player_join(data):
     player_name = data.get("name")
     role_id = data.get("role")
 
-    game = SESSIONS.get_session(code)
+    game = _get_game_or_load(code)
     if not game:
         emit("error", {"message": f"Session {code} not found"})
         return
@@ -106,10 +175,9 @@ def on_player_join(data):
         role_id=role.id,
         position_city_id=start_city.id
     )
-    game.add_player(db_player.id, player_name, role_id)
-    
     db.session.add(db_player)
     db.session.commit()
+    game.add_player(db_player.id, player_name, role_id)
 
     join_room(code)
 
@@ -122,14 +190,16 @@ def on_player_join(data):
 def on_start_game(data):
     code = data.get("code")
 
-    game = SESSIONS.get_session(code)
+    game = _get_game_or_load(code)
     if not game:
         emit("error", {"message": f"Session {code} not found"})
         return
 
-    game.phase = "playing"
-    
-    emit("game_started", {}, to=code)
+    result = game.start_game()
+    if result.get("status") == 200:
+        emit("game_started", result, to=code)
+    else:
+        emit("error", {"message": result.get("message", "Не удалось начать игру")}, room=request.sid)
 
 # ------------------------------
 # REST endpoints — PlayerModel actions
@@ -137,56 +207,45 @@ def on_start_game(data):
 
 @api.post("/player/move")
 def post_player_move() -> Any:
-    data = request.get_json()
+    data = request.get_json() or {}
 
     player_id = data.get("player_id")
     to_city_name = data.get("to_city")
-    transport = data.get("transport", "drive")
-
-    print(f'player-move: {player_id}, {to_city_name}, {transport}')
+    card_id = data.get("card_id")
 
     if not all([player_id, to_city_name]):
         return jsonify({"status": "error", "message": "Missing required fields"}), 400
     
     # Проверяем игрока и целевой город
-    player = PlayerModel.query.get(player_id)
-    if not player:
-        return jsonify({"error": "PlayerModel not found"}), 404
+    player_model = PlayerModel.query.get(player_id)
+    if not player_model:
+        return jsonify({"status": "error", "message": "PlayerModel not found"}), 404
 
-    new_city = CityModel.query.filter_by(name=to_city_name).first()
-    if not new_city:
-        return jsonify({"status": "error", "message": "CityModel not found"}), 404
-
-    game = SESSIONS.get_session(player.session_code)
+    game = _get_game_or_load(player_model.game_id)
     if not game:
-        return jsonify({"status": "error", "message": f"Session {player.session_code} not found"}), 404
+        return jsonify({"status": "error", "message": f"Session {player_model.game_id} not found"}), 404
+
+    player = _get_player_from_game(game, player_id)
+    if not player:
+        return jsonify({"status": "error", "message": "Player not in game"}), 404
+
+    card = _get_card_from_game(game, card_id)
 
     try:
-        result = game.move(player, to_city_name, transport)
+        result = game.move_player(player_id, to_city_name, card)
+        status = result.get("status", 500)
 
-        if result == 200:
-            notify_player_moved(player.session_code, player, to_city_name)
-            return jsonify({
-                "status": "ok",
-                "player_id": player.id,
-                "new_city": to_city_name,
-                "actions_left": player.actions_left
-            }), 200
-        elif result == 403:
-            return jsonify({"status": "error", "message": "Move not allowed"}), 403
-        elif result == 404:
-            return jsonify({"status": "error", "message": "Invalid city"}), 404
-        else:
-            return jsonify({"status": "error", "message": "Internal error"}), 500
-
+        if status == 200:
+            notify_player_moved(player_model.game_id, player, to_city_name)
+            _emit_log(player_model.game_id, f"{player.name} переместился в {to_city_name}", {"player_id": player_id})
+        return jsonify(result), status
     except Exception as e:
         db.session.rollback()
         print(f"[MoveError] {e}")
-        return jsonify({"status": "error", "message": "Database error"}), 500
+        return jsonify({"status": "error", "message": "Internal error"}), 500
 
 @api.post("/player/use-event")
 def post_player_use_event() -> Any:
-    pass
     """Use an event card.
 
     Expected JSON:
@@ -197,10 +256,38 @@ def post_player_use_event() -> Any:
     "payload": dict | null # event-specific arguments (city, target, etc.)
     }
     """
+    data = request.get_json() or {}
+
+    game_id = data.get("game_id")
+    player_id = data.get("player_id")
+    card_id = data.get("event_card_id")
+
+    if not all([game_id, player_id, card_id]):
+        return jsonify({"status": "error", "message": "Missing required fields"}), 400
+
+    game = _get_game_or_load(game_id)
+    if not game:
+        return jsonify({"status": "error", "message": "Game not found"}), 404
+
+    card = _get_card_from_game(game, int(card_id))
+    player = _get_player_from_game(game, int(player_id))
+
+    if not player:
+        return jsonify({"status": "error", "message": "Player not in game"}), 404
+    if not card:
+        return jsonify({"status": "error", "message": "Card not found"}), 404
+
+    result = game.use_event_player(int(player_id), card)
+    status = result.get("status", 500)
+
+    if status == 200:
+        socketio.emit("player:used_event", {"player_id": player_id, "card_id": card_id}, room=game_id)
+        _emit_log(game_id, f"{player.name} использовал карту события {card.name}")
+
+    return jsonify(result), status
 
 @api.post("/player/build-research-station")
 def post_player_build_research_station() -> Any:
-    pass
     """Build a research station in a city.
     
     
@@ -212,10 +299,36 @@ def post_player_build_research_station() -> Any:
     "card_id": str | null # optional per "soft rules"
     }
     """
+    data = request.get_json() or {}
+    game_id = data.get("game_id")
+    player_id = data.get("player_id")
+    city_name = data.get("city")
+    card_id = data.get("card_id")
+
+    if not all([game_id, player_id, city_name]):
+        return jsonify({"status": "error", "message": "Missing required fields"}), 400
+
+    game = _get_game_or_load(game_id)
+    if not game:
+        return jsonify({"status": "error", "message": "Game not found"}), 404
+
+    card = _get_card_from_game(game, int(card_id)) if card_id is not None else None
+    player = _get_player_from_game(game, int(player_id))
+
+    if not player:
+        return jsonify({"status": "error", "message": "Player not in game"}), 404
+
+    result = game.build_research_station_player(int(player_id), city_name, card)
+    status = result.get("status", 500)
+
+    if status == 200:
+        socketio.emit("player:built_station", {"player_id": player_id, "city": city_name}, room=game_id)
+        _emit_log(game_id, f"{player.name} построил исследовательскую станцию в {city_name}")
+
+    return jsonify(result), status
 
 @api.post("/player/trade-card")
 def post_player_trade_card() -> Any:
-    pass
     """Trade (share knowledge) between players.
     
     
@@ -228,10 +341,43 @@ def post_player_trade_card() -> Any:
     "city": str | null # optional; classical rules often require same city
     }
     """
+    data = request.get_json() or {}
+    game_id = data.get("game_id")
+    from_player_id = data.get("from_player_id")
+    to_player_id = data.get("to_player_id")
+    card_id = data.get("card_id")
+
+    if not all([game_id, from_player_id, to_player_id, card_id]):
+        return jsonify({"status": "error", "message": "Missing required fields"}), 400
+
+    game = _get_game_or_load(game_id)
+    if not game:
+        return jsonify({"status": "error", "message": "Game not found"}), 404
+
+    from_player = _get_player_from_game(game, int(from_player_id))
+    to_player = _get_player_from_game(game, int(to_player_id))
+    card = _get_card_from_game(game, int(card_id))
+
+    if not from_player or not to_player:
+        return jsonify({"status": "error", "message": "Player not in game"}), 404
+    if not card:
+        return jsonify({"status": "error", "message": "Card not found"}), 404
+
+    result = game.trade_card_player(int(from_player_id), int(to_player_id), card)
+    status = result.get("status", 500)
+
+    if status == 200:
+        socketio.emit(
+            "player:traded_card",
+            {"from": from_player_id, "to": to_player_id, "card_id": card_id},
+            room=game_id,
+        )
+        _emit_log(game_id, f"{from_player.name} передал карту {card.name} игроку {to_player.name}")
+
+    return jsonify(result), status
 
 @api.post("/player/discover-cure")
 def post_player_discover_cure() -> Any:
-    pass
     """Discover a cure for a disease color.
     
     
@@ -243,10 +389,49 @@ def post_player_discover_cure() -> Any:
     "card_ids": list[str] # typically 4/5 cards by rules; soft-checked here
     }
     """
+    data = request.get_json() or {}
+    game_id = data.get("game_id")
+    player_id = data.get("player_id")
+    color_name = (data.get("color") or "").lower()
+    card_ids = data.get("card_ids") or []
+
+    if not all([game_id, player_id, color_name, card_ids]):
+        return jsonify({"status": "error", "message": "Missing required fields"}), 400
+
+    game = _get_game_or_load(game_id)
+    if not game:
+        return jsonify({"status": "error", "message": "Game not found"}), 404
+
+    from data.enums import ColorType
+
+    try:
+        color_type = getattr(ColorType, color_name)
+    except Exception:
+        return jsonify({"status": "error", "message": "Invalid color"}), 400
+
+    try:
+        cards = [_get_card_from_game(game, int(c_id)) for c_id in card_ids]
+    except Exception:
+        return jsonify({"status": "error", "message": "Invalid card id"}), 400
+
+    if any(card is None for card in cards):
+        return jsonify({"status": "error", "message": "Card not found"}), 404
+
+    player = _get_player_from_game(game, int(player_id))
+    if not player:
+        return jsonify({"status": "error", "message": "Player not in game"}), 404
+
+    result = game.discover_cure_player(int(player_id), color_type, cards)  # type: ignore[arg-type]
+    status = result.get("status", 500)
+
+    if status == 200:
+        socketio.emit("player:discovered_cure", {"player_id": player_id, "color": color_name}, room=game_id)
+        _emit_log(game_id, f"{player.name} открыл лекарство от {color_name}")
+
+    return jsonify(result), status
 
 @api.post("/player/discard-card")
 def post_player_discard_card() -> Any:
-    pass
     """Discard a card from the player's hand.
     
     
@@ -257,10 +442,31 @@ def post_player_discard_card() -> Any:
     "card_id": str
     }
     """
+    data = request.get_json() or {}
+    game_id = data.get("game_id")
+    player_id = data.get("player_id")
+    card_id = data.get("card_id")
+
+    if not all([game_id, player_id, card_id]):
+        return jsonify({"status": "error", "message": "Missing required fields"}), 400
+
+    game = _get_game_or_load(game_id)
+    if not game:
+        return jsonify({"status": "error", "message": "Game not found"}), 404
+
+    card = _get_card_from_game(game, int(card_id))
+    if not card:
+        return jsonify({"status": "error", "message": "Card not found"}), 404
+
+    card.player_owner = None
+    card.use()
+
+    _emit_log(game_id, f"Карта {card.name} сброшена", {"player_id": player_id})
+
+    return jsonify({"status": "ok", "message": "Card discarded"}), 200
 
 @api.post("/player/end-action")
 def post_player_end_action() -> Any:
-    pass
     """Explicitly end a single action (client keeps count up to 4 per turn).
     
     
@@ -271,13 +477,31 @@ def post_player_end_action() -> Any:
     "action_counter": int | null # client-side count; server may verify
     }
     """
+    data = request.get_json() or {}
+    game_id = data.get("game_id")
+
+    if not game_id:
+        return jsonify({"status": "error", "message": "Missing game_id"}), 400
+
+    game = _get_game_or_load(game_id)
+    if not game:
+        return jsonify({"status": "error", "message": "Game not found"}), 404
+
+    result = game.notify_turn_ended()
+    status = result.get("status", 500)
+
+    if status == 200:
+        notify_turn_ended(game_id, data.get("player_id"), None)
+        _emit_log(game_id, "Ход завершён")
+
+    return jsonify(result), status
 
 # ------------------------------
-# Socket.IO — PlayerModel action events (namespace=/game)
+# Socket.IO — PlayerModel action events (namespace=/)
 # ------------------------------
 
 
-NAMESPACE = "/game"
+NAMESPACE = "/"
 
 @socketio.on("player:move", namespace=NAMESPACE)
 def sio_player_move(data) -> None:
@@ -285,53 +509,217 @@ def sio_player_move(data) -> None:
     code = data.get("game_code")
     player_id = data.get("player_id")
     to_city_name = data.get("to_city")
-    transport = data.get("transport", "drive")
     card_id = data.get("card_id")
 
     if not all([code, player_id, to_city_name]):
         emit("player:move:error", {"message": "Missing required fields"}, room=request.sid)
         return
 
-    game = SESSIONS.get_session(code)
+    game = _get_game_or_load(code)
     if not game:
         emit("player:move:error", {"message": f"Session {code} not found"}, room=request.sid)
         return
 
-    status, position = game.move(player_id, to_city_name, transport, card_id)
+    player = _get_player_from_game(game, int(player_id))
+    card = _get_card_from_game(game, int(card_id)) if card_id is not None else None
+
+    if not player:
+        emit("player:move:error", {"message": "Player not in game"}, room=request.sid)
+        return
+
+    try:
+        result = game.move_player(int(player_id), to_city_name, card)
+        status = result.get("status", 500)
+    except Exception as e:
+        print(f"[sio_move] {e}")
+        emit("player:move:error", {"message": "Internal error"}, room=request.sid)
+        return
 
     if status == 200:
-        emit("player:moved", {"player_id": player_id, "new_city": to_city_name}, room=code)
-    elif status == 403:
-        emit("player:move:error", {"message": "Move not allowed"}, room=request.sid)
-    elif status == 404:
-        emit("player:move:error", {"message": "CityModel not found"}, room=request.sid)
+        notify_player_moved(code, player, to_city_name)
+        emit("player:moved:ack", {"player_id": player_id, "new_city": to_city_name}, room=request.sid)
     else:
-        emit("player:move:error", {"message": "Internal error"}, room=request.sid)
-    
+        emit("player:move:error", {"message": result.get("message", "Move failed")}, room=request.sid)
 
 @socketio.on("player:use_event", namespace=NAMESPACE)
 def sio_player_use_event(data: Dict[str, Any]) -> None:
-    pass
+    game_id = data.get("game_id")
+    player_id = data.get("player_id")
+    card_id = data.get("event_card_id")
+
+    if not all([game_id, player_id, card_id]):
+        emit("player:use_event:error", {"message": "Missing required fields"}, room=request.sid)
+        return
+
+    game = _get_game_or_load(game_id)
+    card = _get_card_from_game(game, int(card_id)) if game else None
+    player = _get_player_from_game(game, int(player_id)) if game else None
+
+    if not game:
+        emit("player:use_event:error", {"message": "Game not found"}, room=request.sid)
+        return
+    if not player or not card:
+        emit("player:use_event:error", {"message": "Player or card not found"}, room=request.sid)
+        return
+
+    result = game.use_event_player(int(player_id), card)
+    status = result.get("status", 500)
+    if status == 200:
+        socketio.emit("player:used_event", {"player_id": player_id, "card_id": card_id}, room=game_id)
+        _emit_log(game_id, f"{player.name} использовал карту события {card.name}")
+    else:
+        emit("player:use_event:error", {"message": result.get("message")}, room=request.sid)
 
 @socketio.on("player:build_station", namespace=NAMESPACE)
 def sio_player_build_station(data: Dict[str, Any]) -> None:
-    pass
+    game_id = data.get("game_id")
+    player_id = data.get("player_id")
+    city_name = data.get("city")
+    card_id = data.get("card_id")
+
+    if not all([game_id, player_id, city_name]):
+        emit("player:build_station:error", {"message": "Missing required fields"}, room=request.sid)
+        return
+
+    game = _get_game_or_load(game_id)
+    card = _get_card_from_game(game, int(card_id)) if game and card_id is not None else None
+    player = _get_player_from_game(game, int(player_id)) if game else None
+
+    if not game or not player:
+        emit("player:build_station:error", {"message": "Game or player not found"}, room=request.sid)
+        return
+
+    result = game.build_research_station_player(int(player_id), city_name, card)
+    status = result.get("status", 500)
+    if status == 200:
+        socketio.emit("player:built_station", {"player_id": player_id, "city": city_name}, room=game_id)
+        _emit_log(game_id, f"{player.name} построил исследовательскую станцию в {city_name}")
+    else:
+        emit("player:build_station:error", {"message": result.get("message")}, room=request.sid)
 
 @socketio.on("player:trade_card", namespace=NAMESPACE)
 def sio_player_trade_card(data: Dict[str, Any]) -> None:
-    pass
+    game_id = data.get("game_id")
+    from_player_id = data.get("from_player_id")
+    to_player_id = data.get("to_player_id")
+    card_id = data.get("card_id")
+
+    if not all([game_id, from_player_id, to_player_id, card_id]):
+        emit("player:trade_card:error", {"message": "Missing required fields"}, room=request.sid)
+        return
+
+    game = _get_game_or_load(game_id)
+    if not game:
+        emit("player:trade_card:error", {"message": "Game not found"}, room=request.sid)
+        return
+
+    from_player = _get_player_from_game(game, int(from_player_id))
+    to_player = _get_player_from_game(game, int(to_player_id))
+    card = _get_card_from_game(game, int(card_id))
+
+    if not from_player or not to_player or not card:
+        emit("player:trade_card:error", {"message": "Invalid payload"}, room=request.sid)
+        return
+
+    result = game.trade_card_player(int(from_player_id), int(to_player_id), card)
+    status = result.get("status", 500)
+    if status == 200:
+        socketio.emit(
+            "player:traded_card",
+            {"from": from_player_id, "to": to_player_id, "card_id": card_id},
+            room=game_id,
+        )
+        _emit_log(game_id, f"{from_player.name} передал карту {card.name} игроку {to_player.name}")
+    else:
+        emit("player:trade_card:error", {"message": result.get("message")}, room=request.sid)
 
 @socketio.on("player:discover_cure", namespace=NAMESPACE)
 def sio_player_discover_cure(data: Dict[str, Any]) -> None:
-    pass
+    game_id = data.get("game_id")
+    player_id = data.get("player_id")
+    color_name = (data.get("color") or "").lower()
+    card_ids = data.get("card_ids") or []
+
+    if not all([game_id, player_id, color_name, card_ids]):
+        emit("player:discover_cure:error", {"message": "Missing required fields"}, room=request.sid)
+        return
+
+    game = _get_game_or_load(game_id)
+    if not game:
+        emit("player:discover_cure:error", {"message": "Game not found"}, room=request.sid)
+        return
+
+    from data.enums import ColorType
+    try:
+        color_type = getattr(ColorType, color_name)
+    except Exception:
+        emit("player:discover_cure:error", {"message": "Invalid color"}, room=request.sid)
+        return
+
+    try:
+        cards = [_get_card_from_game(game, int(c_id)) for c_id in card_ids]
+    except Exception:
+        emit("player:discover_cure:error", {"message": "Invalid cards"}, room=request.sid)
+        return
+
+    if any(card is None for card in cards):
+        emit("player:discover_cure:error", {"message": "Card not found"}, room=request.sid)
+        return
+
+    player = _get_player_from_game(game, int(player_id))
+    if not player:
+        emit("player:discover_cure:error", {"message": "Player not in game"}, room=request.sid)
+        return
+
+    result = game.discover_cure_player(int(player_id), color_type, cards)  # type: ignore[arg-type]
+    status = result.get("status", 500)
+
+    if status == 200:
+        socketio.emit("player:discovered_cure", {"player_id": player_id, "color": color_name}, room=game_id)
+        _emit_log(game_id, f"{player.name} открыл лекарство от {color_name}")
+    else:
+        emit("player:discover_cure:error", {"message": result.get("message")}, room=request.sid)
 
 @socketio.on("player:discard_card", namespace=NAMESPACE)
 def sio_player_discard_card(data: Dict[str, Any]) -> None:
-    pass
+    game_id = data.get("game_id")
+    player_id = data.get("player_id")
+    card_id = data.get("card_id")
+
+    if not all([game_id, player_id, card_id]):
+        emit("player:discard_card:error", {"message": "Missing required fields"}, room=request.sid)
+        return
+
+    game = _get_game_or_load(game_id)
+    card = _get_card_from_game(game, int(card_id)) if game else None
+
+    if not game or not card:
+        emit("player:discard_card:error", {"message": "Game or card not found"}, room=request.sid)
+        return
+
+    card.player_owner = None
+    card.use()
+    _emit_log(game_id, f"Карта {card.name} сброшена", {"player_id": player_id})
+    emit("player:discarded_card", {"card_id": card_id}, room=game_id)
 
 @socketio.on("player:end_action", namespace=NAMESPACE)
 def sio_player_end_action(data: Dict[str, Any]) -> None:
-    pass
+    game_id = data.get("game_id")
+    if not game_id:
+        emit("player:end_action:error", {"message": "Missing game_id"}, room=request.sid)
+        return
+
+    game = _get_game_or_load(game_id)
+    if not game:
+        emit("player:end_action:error", {"message": "Game not found"}, room=request.sid)
+        return
+
+    result = game.notify_turn_ended()
+    status = result.get("status", 500)
+    if status == 200:
+        notify_turn_ended(game_id, data.get("player_id"), None)
+    else:
+        emit("player:end_action:error", {"message": result.get("message")}, room=request.sid)
 
 # ------------------------------
 # Server-originated game lifecycle notifications
@@ -349,11 +737,10 @@ def notify_player_moved(game_code: str, player: PlayerModel, new_city_name: str)
             "actions_left": player.actions_left
         },
         room=game_code,
-        namespace="/game"
+        namespace=NAMESPACE
     )
 
 def notify_turn_ended(game_id: str, player_id: str, next_player_id: str) -> None:
-    pass
     """Broadcast end of the current player's turn.
     Payload suggestion:
     {
@@ -364,9 +751,16 @@ def notify_turn_ended(game_id: str, player_id: str, next_player_id: str) -> None
     }
     Emits: "server:turn_ended" to /game and /host.
     """
+    payload = {
+        "game_id": game_id,
+        "ended_player_id": player_id,
+        "next_player_id": next_player_id,
+    }
+    socketio.emit(SERVER_EVENTS["turn_ended"], payload, room=game_id, namespace=NAMESPACE)
+    socketio.emit(SERVER_EVENTS["turn_ended"], payload, room=game_id)
+    _emit_log(game_id, "Ход завершён", payload)
 
 def notify_player_drew_cards(game_id: str, player_id: str, card_ids: list[str], reshuffle_discard: bool | None = None) -> None:
-    pass
     """Broadcast that a player drew cards from the player deck.
     Payload suggestion:
     {
@@ -377,12 +771,16 @@ def notify_player_drew_cards(game_id: str, player_id: str, card_ids: list[str], 
     }
     Emits: "server:player_drew_cards".
     """
-
-
-
+    payload = {
+        "game_id": game_id,
+        "player_id": player_id,
+        "card_ids": card_ids,
+        "reshuffle_discard": reshuffle_discard,
+    }
+    socketio.emit(SERVER_EVENTS["player_drew_cards"], payload, room=game_id, namespace=NAMESPACE)
+    _emit_log(game_id, f"Игрок {player_id} добрал карты", payload)
 
 def notify_disease_spread(game_id: str, city: str, color: str, cubes_added: int, chain: list[dict] | None = None) -> None:
-    pass
     """Broadcast disease spread in a city (normal infection step).
     Payload suggestion:
     {
@@ -394,11 +792,17 @@ def notify_disease_spread(game_id: str, city: str, color: str, cubes_added: int,
     }
     Emits: "server:disease_spread".
     """
-
-
+    payload = {
+        "game_id": game_id,
+        "city": city,
+        "color": color,
+        "cubes_added": cubes_added,
+        "chain": chain,
+    }
+    socketio.emit(SERVER_EVENTS["disease_spread"], payload, room=game_id, namespace=NAMESPACE)
+    _emit_log(game_id, f"Инфекция распространяется в {city}", payload)
 
 def notify_epidemic(game_id: str, city: str, color: str, infection_rate: int, intensify: bool) -> None:
-    pass
     """Broadcast epidemic event (draw bottom card, increase rate, intensify).
     Payload suggestion:
     {
@@ -410,12 +814,17 @@ def notify_epidemic(game_id: str, city: str, color: str, infection_rate: int, in
     }
     Emits: "server:epidemic".
     """
-
-
-
+    payload = {
+        "game_id": game_id,
+        "city": city,
+        "color": color,
+        "infection_rate": infection_rate,
+        "intensify": intensify,
+    }
+    socketio.emit(SERVER_EVENTS["epidemic"], payload, room=game_id, namespace=NAMESPACE)
+    _emit_log(game_id, f"Эпидемия в {city}", payload)
 
 def notify_outbreak(game_id: str, origin_city: str, color: str, affected: list[str], outbreak_count: int) -> None:
-    pass
     """Broadcast an outbreak and list affected cities.
     Payload suggestion:
     {
@@ -427,9 +836,17 @@ def notify_outbreak(game_id: str, origin_city: str, color: str, affected: list[s
     }
     Emits: "server:outbreak".
     """
+    payload = {
+        "game_id": game_id,
+        "origin_city": origin_city,
+        "color": color,
+        "affected": affected,
+        "outbreak_count": outbreak_count,
+    }
+    socketio.emit(SERVER_EVENTS["outbreak"], payload, room=game_id, namespace=NAMESPACE)
+    _emit_log(game_id, f"Вспышка болезни в {origin_city}", payload)
 
 def notify_disease_cured(game_id: str, color: str, eradicated: bool) -> None:
-    pass
     """Broadcast that a disease was cured (and whether it is eradicated).
     Payload suggestion:
     {
@@ -439,9 +856,11 @@ def notify_disease_cured(game_id: str, color: str, eradicated: bool) -> None:
     }
     Emits: "server:disease_cured".
     """
+    payload = {"game_id": game_id, "color": color, "eradicated": eradicated}
+    socketio.emit(SERVER_EVENTS["disease_cured"], payload, room=game_id, namespace=NAMESPACE)
+    _emit_log(game_id, f"Лекарство от {color} {'уничтожило болезнь' if eradicated else 'создано'}", payload)
 
 def notify_game_over(game_id: str, outcome: str, reason: str | None = None, stats: dict | None = None) -> None:
-    pass
     """Broadcast game end.
     Payload suggestion:
     {
@@ -452,6 +871,14 @@ def notify_game_over(game_id: str, outcome: str, reason: str | None = None, stat
     }
     Emits: "server:game_over".
     """
+    payload = {
+        "game_id": game_id,
+        "outcome": outcome,
+        "reason": reason,
+        "stats": stats,
+    }
+    socketio.emit(SERVER_EVENTS["game_over"], payload, room=game_id, namespace=NAMESPACE)
+    _emit_log(game_id, f"Игра завершена ({outcome})", payload)
 
 
 SERVER_EVENTS = {

--- a/static/js/board.js
+++ b/static/js/board.js
@@ -1,21 +1,42 @@
 ﻿const code = "{{ code }}";
 const socket = io();
 
+function appendLog(text) {
+    const logContainer = document.getElementById("log-messages");
+    if (!logContainer) return;
+    const item = document.createElement("div");
+    item.textContent = text;
+    logContainer.prepend(item);
+}
+
 socket.emit("host_join", { code });
 
 socket.on("player_joined", (data) => {
     const list = document.getElementById("player-list");
     const li = document.createElement("li");
-    li.textContent = data.name;
+    li.textContent = data.role ? `${data.name} — ${data.role}` : data.name;
     list.appendChild(li);
+    appendLog(`Подключился ${data.name}`);
 });
 
 socket.on("player:moved", (data) => {
-    const log = document.createElement("p");
-    log.textContent = `Игрок ${data.player_id} переместился в ${data.new_city}`;
-    document.body.appendChild(log);
+    appendLog(`Игрок ${data.player_id} переместился в ${data.new_city}`);
+});
+
+socket.on("player:traded_card", (data) => {
+    appendLog(`Игрок ${data.from} передал карту ${data.card_id} игроку ${data.to}`);
+});
+
+socket.on("player:built_station", (data) => {
+    appendLog(`Построена станция в ${data.city}`);
 });
 
 socket.on("game_started", () => {
-    alert("Игра началась!");
+    appendLog("Игра началась");
+});
+
+socket.on("game:log", (data) => {
+    if (data && data.text) {
+        appendLog(data.text);
+    }
 });

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -3,6 +3,14 @@ const name = "{{ name }}";
 const playerId = "{{ player_id }}";
 const socket = io();
 
+function appendLog(text) {
+    const log = document.getElementById("log");
+    if (!log) return;
+    const p = document.createElement("p");
+    p.textContent = text;
+    log.prepend(p);
+}
+
 socket.emit("player_join", { code, name });
 
 document.getElementById("move-btn").addEventListener("click", () => {
@@ -18,8 +26,15 @@ socket.on("player:moved", (data) => {
     if (data.player_id == playerId) {
         document.getElementById("actions-left").textContent = data.actions_left;
     }
-    const log = document.getElementById("log");
-    const p = document.createElement("p");
-    p.textContent = `Игрок ${data.player_id} переместился в ${data.new_city}`;
-    log.appendChild(p);
+    appendLog(`Игрок ${data.player_id} переместился в ${data.new_city}`);
+});
+
+socket.on("player:move:error", (data) => {
+    appendLog(data.message || "Не удалось переместиться");
+});
+
+socket.on("game:log", (data) => {
+    if (data && data.text) {
+        appendLog(data.text);
+    }
 });

--- a/templates/board.html
+++ b/templates/board.html
@@ -20,6 +20,11 @@
             <h3>Игроки</h3>
             <ul id="player-list"></ul>
         </div>
+
+        <div id="action-log">
+            <h3>Лог действий</h3>
+            <div id="log-messages"></div>
+        </div>
     </section>
 {% endblock %}
 {% block scripts %}


### PR DESCRIPTION
## Summary
- implement all controller REST and Socket.IO handlers to drive PandemicGame actions and broadcast results
- attach per-game observers to relay game updates over sockets and add structured logging
- surface action logs in the board and player pages and load player identifiers for client actions

## Testing
- python -m compileall controller.py app.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69419dda05a88325911c75944e805acb)